### PR TITLE
Remove minimum length constraint on EmployeeId

### DIFF
--- a/NorthwindCRUD/Models/Dtos/EmployeeDto.cs
+++ b/NorthwindCRUD/Models/Dtos/EmployeeDto.cs
@@ -7,7 +7,6 @@ namespace NorthwindCRUD.Models.Dtos
     public class EmployeeDto : IEmployee
     {
         [SwaggerSchema("Number automatically assigned to new employee.")]
-        [MinLength(8)] // Min length comes from IdGenerator.CreateDigitsId
         [Required]
         public int EmployeeId { get; set; }
 


### PR DESCRIPTION
Remove minimum length constraint on EmployeeId as this validation is applicable only for string and collection types.

The minimum length attribute previously applied to EmployeeId in EmployeeDto.cs was removed. There were unnecessary limitations being put on the EmployeeId property, which is intended to be automatically generated and required, but not to impose a minimum length.