### PR TITLE
Update remote paging endpoint

### DIFF
--- a/NorthwindCRUD/Attributes/SwaggerParameterAttributes.cs
+++ b/NorthwindCRUD/Attributes/SwaggerParameterAttributes.cs
@@ -1,0 +1,28 @@
+﻿using Swashbuckle.AspNetCore.Annotations;
+
+namespace NorthwindCRUD.Attributes
+{
+        public class SwaggerPageParameterAttribute : SwaggerParameterAttribute
+        {
+            public SwaggerPageParameterAttribute()
+                : base("The page index of records to fetch. If this parameter is not provided, fetching starts from the beginning (page 0).")
+            {
+            }
+        }
+
+        public class SwaggerSizeParameterAttribute : SwaggerParameterAttribute
+        {
+            public SwaggerSizeParameterAttribute()
+                : base("The maximum number of records to fetch per page. If this parameter is not provided, all records are fetched.")
+            {
+            }
+        }
+
+        public class SwaggerOrderByParameterAttribute : SwaggerParameterAttribute
+        {
+            public SwaggerOrderByParameterAttribute()
+                : base("A comma-separated list of fields to order the records by, along with the sort direction (e.g., 'field1 asc, field2 desc').")
+            {
+            }
+        }
+}

--- a/NorthwindCRUD/Attributes/SwaggerParameterAttributes.cs
+++ b/NorthwindCRUD/Attributes/SwaggerParameterAttributes.cs
@@ -25,4 +25,20 @@ namespace NorthwindCRUD.Attributes
             {
             }
         }
+
+        public class SwaggerSkipParameterAttribute : SwaggerParameterAttribute
+        {
+            public SwaggerSkipParameterAttribute()
+                : base("The number of records to skip before starting to fetch them. If this parameter is not provided, fetching starts from the beginning.")
+            {
+            }
+        }
+
+        public class SwaggerTopParameterAttribute : SwaggerParameterAttribute
+        {
+            public SwaggerTopParameterAttribute()
+                : base("The maximum number of records to fetch. If this parameter is not provided, all records are fetched.")
+            {
+            }
+        }
 }

--- a/NorthwindCRUD/Controllers/CategoriesController.cs
+++ b/NorthwindCRUD/Controllers/CategoriesController.cs
@@ -102,6 +102,25 @@ namespace NorthwindCRUD.Controllers
             }
         }
 
+        /// <summary>
+        /// Retrieves the total number of categories.
+        /// </summary>
+        /// <returns>Total count of categories as an integer.</returns>
+        [HttpGet("GetCategoriesCount")]
+        public ActionResult<int> GetCategoriesCount()
+        {
+            try
+            {
+                var count = categoryService.GetAllAsQueryable().Count();
+                return Ok(count);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
         [HttpGet("{id}")]
         public ActionResult<CategoryDto> GetById(int id)
         {

--- a/NorthwindCRUD/Controllers/CategoriesController.cs
+++ b/NorthwindCRUD/Controllers/CategoriesController.cs
@@ -107,12 +107,12 @@ namespace NorthwindCRUD.Controllers
         /// </summary>
         /// <returns>Total count of categories as an integer.</returns>
         [HttpGet("GetCategoriesCount")]
-        public ActionResult<int> GetCategoriesCount()
+        public ActionResult<CountResultDto> GetCategoriesCount()
         {
             try
             {
                 var count = categoryService.GetAllAsQueryable().Count();
-                return Ok(count);
+                return new CountResultDto() { Count = count };
             }
             catch (Exception error)
             {

--- a/NorthwindCRUD/Controllers/CategoriesController.cs
+++ b/NorthwindCRUD/Controllers/CategoriesController.cs
@@ -51,9 +51,9 @@ namespace NorthwindCRUD.Controllers
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetCategoriesWithSkip")]
         public ActionResult<PagedResultDto<CategoryDto>> GetCategoriesWithSkip(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch them. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of records to fetch. If this parameter is not provided, all records are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the records by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+            [FromQuery][Attributes.SwaggerSkipParameter] int? skip,
+            [FromQuery][Attributes.SwaggerTopParameter] int? top,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
         {
             try
             {

--- a/NorthwindCRUD/Controllers/CategoriesController.cs
+++ b/NorthwindCRUD/Controllers/CategoriesController.cs
@@ -6,6 +6,7 @@ namespace NorthwindCRUD.Controllers
     using NorthwindCRUD.Models.DbModels;
     using NorthwindCRUD.Models.Dtos;
     using NorthwindCRUD.Services;
+    using Swashbuckle.AspNetCore.Annotations;
 
     [ApiController]
     [Route("[controller]")]
@@ -49,15 +50,18 @@ namespace NorthwindCRUD.Controllers
         /// <param name="orderBy">A comma-separated list of fields to order the categories by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedCategories")]
-        public ActionResult<PagedResultDto<ProductDto>> GetPagedCategories(int? skip, int? top, string? orderBy)
+        public ActionResult<PagedResultDto<ProductDto>> GetPagedCategories(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the categories. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of categories to fetch. If this parameter is not provided, all categories are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the categories by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
-                // Retrieve all categories
-                var categories = this.categoryService.GetAll();
+                // Retrieve categories as Queryable
+                var categories = this.categoryService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.GetPagedData<CategoryDb, CategoryDto>(categories, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedDataWithSkip<CategoryDb, CategoryDto>(categories, skip, top, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/CategoriesController.cs
+++ b/NorthwindCRUD/Controllers/CategoriesController.cs
@@ -49,11 +49,11 @@ namespace NorthwindCRUD.Controllers
         /// <param name="top">The maximum number of categories to fetch. If this parameter is not provided, all categories are fetched.</param>
         /// <param name="orderBy">A comma-separated list of fields to order the categories by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
-        [HttpGet("GetPagedCategories")]
-        public ActionResult<PagedResultDto<ProductDto>> GetPagedCategories(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the categories. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of categories to fetch. If this parameter is not provided, all categories are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the categories by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+        [HttpGet("GetCategoriesWithSkip")]
+        public ActionResult<PagedResultDto<CategoryDto>> GetCategoriesWithSkip(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch them. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of records to fetch. If this parameter is not provided, all records are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the records by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
@@ -61,7 +61,37 @@ namespace NorthwindCRUD.Controllers
                 var categories = this.categoryService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.FetchPagedDataWithSkip<CategoryDb, CategoryDto>(categories, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedData<CategoryDb, CategoryDto>(categories, skip, top, null, null, orderBy);
+
+                return Ok(pagedResult);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all categories or a page of categories based on the provided parameters.
+        /// </summary>
+        /// <param name="pageIndex">The page index of records to fetch. If this parameter is not provided, fetching starts from the beginning (page 0).</param>
+        /// <param name="size">The maximum number of records to fetch per page. If this parameter is not provided, all records are fetched.</param>
+        /// <param name="orderBy">A comma-separated list of fields to order the records by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
+        /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
+        [HttpGet("GetCategoriesWithPage")]
+        public ActionResult<PagedResultDto<CategoryDto>> GetCategoriesWithPage(
+            [FromQuery][Attributes.SwaggerPageParameter] int? pageIndex,
+            [FromQuery][Attributes.SwaggerSizeParameter] int? size,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
+        {
+            try
+            {
+                // Retrieve categories as Queryable
+                var categories = this.categoryService.GetAllAsQueryable();
+
+                // Get paged data
+                var pagedResult = pagingService.FetchPagedData<CategoryDb, CategoryDto>(categories, null, null, pageIndex, size, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/CustomersController.cs
+++ b/NorthwindCRUD/Controllers/CustomersController.cs
@@ -51,9 +51,9 @@
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetCustomersWithSkip")]
         public ActionResult<PagedResultDto<CustomerDto>> GetCustomersWithSkip(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch them. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of records to fetch. If this parameter is not provided, all records are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the records by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+            [FromQuery][Attributes.SwaggerSkipParameter] int? skip,
+            [FromQuery][Attributes.SwaggerTopParameter] int? top,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
         {
             try
             {

--- a/NorthwindCRUD/Controllers/CustomersController.cs
+++ b/NorthwindCRUD/Controllers/CustomersController.cs
@@ -6,6 +6,7 @@
     using NorthwindCRUD.Models.DbModels;
     using NorthwindCRUD.Models.Dtos;
     using NorthwindCRUD.Services;
+    using Swashbuckle.AspNetCore.Annotations;
 
     [ApiController]
     [Route("[controller]")]
@@ -49,15 +50,18 @@
         /// <param name="orderBy">A comma-separated list of fields to order the customers by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedCustomers")]
-        public ActionResult<PagedResultDto<CustomerDto>> GetAllCustomers(int? skip, int? top, string? orderBy)
+        public ActionResult<PagedResultDto<CustomerDto>> GetAllCustomers(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the customers. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of customers to fetch. If this parameter is not provided, all customers are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the customers by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
                 // Retrieve all customers
-                var customers = this.customerService.GetAll();
+                var customers = this.customerService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.GetPagedData<CustomerDb, CustomerDto>(customers, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedDataWithSkip<CustomerDb, CustomerDto>(customers, skip, top, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/CustomersController.cs
+++ b/NorthwindCRUD/Controllers/CustomersController.cs
@@ -107,12 +107,12 @@
         /// </summary>
         /// <returns>Total count of customers as an integer.</returns>
         [HttpGet("GetCustomersCount")]
-        public ActionResult<int> GetCustomersCount()
+        public ActionResult<CountResultDto> GetCustomersCount()
         {
             try
             {
                 var count = customerService.GetAllAsQueryable().Count();
-                return Ok(count);
+                return new CountResultDto() { Count = count };
             }
             catch (Exception error)
             {

--- a/NorthwindCRUD/Controllers/CustomersController.cs
+++ b/NorthwindCRUD/Controllers/CustomersController.cs
@@ -102,6 +102,25 @@
             }
         }
 
+        /// <summary>
+        /// Retrieves the total number of customers.
+        /// </summary>
+        /// <returns>Total count of customers as an integer.</returns>
+        [HttpGet("GetCustomersCount")]
+        public ActionResult<int> GetCustomersCount()
+        {
+            try
+            {
+                var count = customerService.GetAllAsQueryable().Count();
+                return Ok(count);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
         [HttpGet("{id}")]
         public ActionResult<CustomerDto> GetById(string id)
         {

--- a/NorthwindCRUD/Controllers/CustomersController.cs
+++ b/NorthwindCRUD/Controllers/CustomersController.cs
@@ -49,11 +49,11 @@
         /// <param name="top">The maximum number of customers to fetch. If this parameter is not provided, all customers are fetched.</param>
         /// <param name="orderBy">A comma-separated list of fields to order the customers by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
-        [HttpGet("GetPagedCustomers")]
-        public ActionResult<PagedResultDto<CustomerDto>> GetAllCustomers(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the customers. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of customers to fetch. If this parameter is not provided, all customers are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the customers by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+        [HttpGet("GetCustomersWithSkip")]
+        public ActionResult<PagedResultDto<CustomerDto>> GetCustomersWithSkip(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch them. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of records to fetch. If this parameter is not provided, all records are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the records by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
@@ -61,7 +61,37 @@
                 var customers = this.customerService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.FetchPagedDataWithSkip<CustomerDb, CustomerDto>(customers, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedData<CustomerDb, CustomerDto>(customers, skip, top, null, null, orderBy);
+
+                return Ok(pagedResult);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all customers or a page of customers based on the provided parameters.
+        /// </summary>
+        /// <param name="pageIndex">The page index of records to fetch. If this parameter is not provided, fetching starts from the beginning (page 0).</param>
+        /// <param name="size">The maximum number of records to fetch per page. If this parameter is not provided, all records are fetched.</param>
+        /// <param name="orderBy">A comma-separated list of fields to order the records by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
+        /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
+        [HttpGet("GetCustomersWithPage")]
+        public ActionResult<PagedResultDto<CustomerDto>> GetCustomersWithPage(
+            [FromQuery][Attributes.SwaggerPageParameter] int? pageIndex,
+            [FromQuery][Attributes.SwaggerSizeParameter] int? size,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
+        {
+            try
+            {
+                // Retrieve customers as Queryable
+                var customers = this.customerService.GetAllAsQueryable();
+
+                // Get paged data
+                var pagedResult = pagingService.FetchPagedData<CustomerDb, CustomerDto>(customers, null, null, pageIndex, size, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/EmployeesController.cs
+++ b/NorthwindCRUD/Controllers/EmployeesController.cs
@@ -53,9 +53,9 @@
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetEmployeesWithSkip")]
         public ActionResult<PagedResultDto<EmployeeDto>> GetPagedEmployees(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the employees. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of employees to fetch. If this parameter is not provided, all employees are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the employees by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+            [FromQuery][Attributes.SwaggerSkipParameter] int? skip,
+            [FromQuery][Attributes.SwaggerTopParameter] int? top,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
         {
             try
             {

--- a/NorthwindCRUD/Controllers/EmployeesController.cs
+++ b/NorthwindCRUD/Controllers/EmployeesController.cs
@@ -110,12 +110,12 @@
         /// </summary>
         /// <returns>Total count of employees as an integer.</returns>
         [HttpGet("GetEmployeesCount")]
-        public ActionResult<int> GetEmployeesCount()
+        public ActionResult<CountResultDto> GetEmployeesCount()
         {
             try
             {
                 var count = employeeService.GetAllAsQueryable().Count();
-                return Ok(count);
+                return new CountResultDto() { Count = count };
             }
             catch (Exception error)
             {

--- a/NorthwindCRUD/Controllers/EmployeesController.cs
+++ b/NorthwindCRUD/Controllers/EmployeesController.cs
@@ -51,7 +51,7 @@
         /// <param name="top">The maximum number of employees to fetch. If this parameter is not provided, all employees are fetched.</param>
         /// <param name="orderBy">A comma-separated list of fields to order the employees by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
-        [HttpGet("GetPagedEmployees")]
+        [HttpGet("GetEmployeesWithSkip")]
         public ActionResult<PagedResultDto<EmployeeDto>> GetPagedEmployees(
             [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the employees. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
             [FromQuery][SwaggerParameter("The maximum number of employees to fetch. If this parameter is not provided, all employees are fetched.")] int? top,
@@ -63,7 +63,37 @@
                 var employees = this.employeeService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.FetchPagedDataWithSkip<EmployeeDb, EmployeeDto>(employees, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedData<EmployeeDb, EmployeeDto>(employees, skip, top, null, null, orderBy);
+
+                return Ok(pagedResult);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all employees or a page of employees based on the provided parameters.
+        /// </summary>
+        /// <param name="pageIndex">The page index of records to fetch. If this parameter is not provided, fetching starts from the beginning (page 0).</param>
+        /// <param name="size">The maximum number of records to fetch per page. If this parameter is not provided, all records are fetched.</param>
+        /// <param name="orderBy">A comma-separated list of fields to order the records by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
+        /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
+        [HttpGet("GetPagedEmployeesWithPage")]
+        public ActionResult<PagedResultDto<EmployeeDto>> GetPagedEmployeesWithPage(
+            [FromQuery][Attributes.SwaggerPageParameter] int? pageIndex,
+            [FromQuery][Attributes.SwaggerSizeParameter] int? size,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
+        {
+            try
+            {
+                // Retrieve employees as Queryable
+                var employees = this.employeeService.GetAllAsQueryable();
+
+                // Get paged data
+                var pagedResult = pagingService.FetchPagedData<EmployeeDb, EmployeeDto>(employees, null, null, pageIndex, size, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/EmployeesController.cs
+++ b/NorthwindCRUD/Controllers/EmployeesController.cs
@@ -6,6 +6,7 @@
     using NorthwindCRUD.Models.DbModels;
     using NorthwindCRUD.Models.Dtos;
     using NorthwindCRUD.Services;
+    using Swashbuckle.AspNetCore.Annotations;
 
     [ApiController]
     [Route("[controller]")]
@@ -51,15 +52,18 @@
         /// <param name="orderBy">A comma-separated list of fields to order the employees by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedEmployees")]
-        public ActionResult<PagedResultDto<EmployeeDto>> GetAllEmployees(int? skip, int? top, string? orderBy)
+        public ActionResult<PagedResultDto<EmployeeDto>> GetPagedEmployees(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the employees. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of employees to fetch. If this parameter is not provided, all employees are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the employees by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
-                // Retrieve all employees
-                var employees = this.employeeService.GetAll();
+                // Retrieve all employees as Queryable
+                var employees = this.employeeService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.GetPagedData<EmployeeDb, EmployeeDto>(employees, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedDataWithSkip<EmployeeDb, EmployeeDto>(employees, skip, top, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/EmployeesController.cs
+++ b/NorthwindCRUD/Controllers/EmployeesController.cs
@@ -104,7 +104,6 @@
             }
         }
 
-
         /// <summary>
         /// Retrieves the total number of employees.
         /// </summary>
@@ -123,7 +122,6 @@
                 return StatusCode(500);
             }
         }
-
 
         [HttpGet("{id}")]
         public ActionResult<EmployeeDto> GetById(int id)

--- a/NorthwindCRUD/Controllers/EmployeesController.cs
+++ b/NorthwindCRUD/Controllers/EmployeesController.cs
@@ -104,6 +104,27 @@
             }
         }
 
+
+        /// <summary>
+        /// Retrieves the total number of employees.
+        /// </summary>
+        /// <returns>Total count of employees as an integer.</returns>
+        [HttpGet("GetEmployeesCount")]
+        public ActionResult<int> GetEmployeesCount()
+        {
+            try
+            {
+                var count = employeeService.GetAllAsQueryable().Count();
+                return Ok(count);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
+
         [HttpGet("{id}")]
         public ActionResult<EmployeeDto> GetById(int id)
         {

--- a/NorthwindCRUD/Controllers/OrdersController.cs
+++ b/NorthwindCRUD/Controllers/OrdersController.cs
@@ -68,7 +68,37 @@
                 var orders = this.orderService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.FetchPagedDataWithSkip<OrderDb, OrderDto>(orders, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedData<OrderDb, OrderDto>(orders, skip, top, null, null, orderBy);
+
+                return Ok(pagedResult);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all orders or a page of orders based on the provided parameters.
+        /// </summary>
+        /// <param name="pageIndex">The page index of records to fetch. If this parameter is not provided, fetching starts from the beginning (page 0).</param>
+        /// <param name="size">The maximum number of records to fetch per page. If this parameter is not provided, all records are fetched.</param>
+        /// <param name="orderBy">A comma-separated list of fields to order the records by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
+        /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
+        [HttpGet("GetPagedOrdersWithPage")]
+        public ActionResult<PagedResultDto<OrderDto>> GetPagedOrdersWithPage(
+            [FromQuery][Attributes.SwaggerPageParameter] int? pageIndex,
+            [FromQuery][Attributes.SwaggerSizeParameter] int? size,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
+        {
+            try
+            {
+                // Retrieve orders as Queryable
+                var orders = this.orderService.GetAllAsQueryable();
+
+                // Get paged data
+                var pagedResult = pagingService.FetchPagedData<OrderDb, OrderDto>(orders, null, null, pageIndex, size, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/OrdersController.cs
+++ b/NorthwindCRUD/Controllers/OrdersController.cs
@@ -7,6 +7,7 @@
     using NorthwindCRUD.Models.Dtos;
     using NorthwindCRUD.Models.InputModels;
     using NorthwindCRUD.Services;
+    using Swashbuckle.AspNetCore.Annotations;
 
     [ApiController]
     [Route("[controller]")]
@@ -56,15 +57,18 @@
         /// <param name="orderBy">A comma-separated list of fields to order the orders by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedOrders")]
-        public ActionResult<PagedResultDto<OrderDto>> GetAllOrders(int? skip, int? top, string? orderBy)
+        public ActionResult<PagedResultDto<OrderDto>> GetAllOrders(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the orders. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of orders to fetch. If this parameter is not provided, all orders are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the orders by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
                 // Retrieve all orders
-                var orders = this.orderService.GetAll();
+                var orders = this.orderService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.GetPagedData<OrderDb, OrderDto>(orders, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedDataWithSkip<OrderDb, OrderDto>(orders, skip, top, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/OrdersController.cs
+++ b/NorthwindCRUD/Controllers/OrdersController.cs
@@ -58,9 +58,9 @@
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedOrders")]
         public ActionResult<PagedResultDto<OrderDto>> GetAllOrders(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the orders. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of orders to fetch. If this parameter is not provided, all orders are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the orders by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+            [FromQuery][Attributes.SwaggerSkipParameter] int? skip,
+            [FromQuery][Attributes.SwaggerTopParameter] int? top,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
         {
             try
             {

--- a/NorthwindCRUD/Controllers/OrdersController.cs
+++ b/NorthwindCRUD/Controllers/OrdersController.cs
@@ -109,6 +109,25 @@
             }
         }
 
+        /// <summary>
+        /// Retrieves the total number of orders.
+        /// </summary>
+        /// <returns>Total count of orders as an integer.</returns>
+        [HttpGet("GetOrdersCount")]
+        public ActionResult<int> GetOrdersCount()
+        {
+            try
+            {
+                var count = orderService.GetAllAsQueryable().Count();
+                return Ok(count);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
         [HttpGet("{id}")]
         public ActionResult<OrderDto> GetById(int id)
         {

--- a/NorthwindCRUD/Controllers/OrdersController.cs
+++ b/NorthwindCRUD/Controllers/OrdersController.cs
@@ -5,9 +5,7 @@
     using Microsoft.AspNetCore.Mvc;
     using NorthwindCRUD.Models.DbModels;
     using NorthwindCRUD.Models.Dtos;
-    using NorthwindCRUD.Models.InputModels;
     using NorthwindCRUD.Services;
-    using Swashbuckle.AspNetCore.Annotations;
 
     [ApiController]
     [Route("[controller]")]
@@ -114,12 +112,12 @@
         /// </summary>
         /// <returns>Total count of orders as an integer.</returns>
         [HttpGet("GetOrdersCount")]
-        public ActionResult<int> GetOrdersCount()
+        public ActionResult<CountResultDto> GetOrdersCount()
         {
             try
             {
                 var count = orderService.GetAllAsQueryable().Count();
-                return Ok(count);
+                return new CountResultDto() { Count = count };
             }
             catch (Exception error)
             {

--- a/NorthwindCRUD/Controllers/ProductsController.cs
+++ b/NorthwindCRUD/Controllers/ProductsController.cs
@@ -108,6 +108,25 @@ namespace NorthwindCRUD.Controllers
             }
         }
 
+        /// <summary>
+        /// Retrieves the total number of products.
+        /// </summary>
+        /// <returns>Total count of products as an integer.</returns>
+        [HttpGet("GetProductsCount")]
+        public ActionResult<int> GetProductsCount()
+        {
+            try
+            {
+                var count = productService.GetAllAsQueryable().Count();
+                return Ok(count);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
         [HttpGet("{id}")]
         public ActionResult<ProductDto> GetById(int id)
         {

--- a/NorthwindCRUD/Controllers/ProductsController.cs
+++ b/NorthwindCRUD/Controllers/ProductsController.cs
@@ -67,7 +67,37 @@ namespace NorthwindCRUD.Controllers
                 var products = this.productService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.FetchPagedDataWithSkip<ProductDb, ProductDto>(products, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedData<ProductDb, ProductDto>(products, skip, top, null, null, orderBy);
+
+                return Ok(pagedResult);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all products or a page of products based on the provided parameters.
+        /// </summary>
+        /// <param name="pageIndex">The page index of records to fetch. If this parameter is not provided, fetching starts from the beginning (page 0).</param>
+        /// <param name="size">The maximum number of records to fetch per page. If this parameter is not provided, all records are fetched.</param>
+        /// <param name="orderBy">A comma-separated list of fields to order the records by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
+        /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
+        [HttpGet("GetPagedProductsWithPage")]
+        public ActionResult<PagedResultDto<ProductDto>> GetPagedProductsWithPage(
+            [FromQuery][Attributes.SwaggerPageParameter] int? pageIndex,
+            [FromQuery][Attributes.SwaggerSizeParameter] int? size,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
+        {
+            try
+            {
+                // Retrieve products as Queryable
+                var products = this.productService.GetAllAsQueryable();
+
+                // Get paged data
+                var pagedResult = pagingService.FetchPagedData<ProductDb, ProductDto>(products, null, null, pageIndex, size, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/ProductsController.cs
+++ b/NorthwindCRUD/Controllers/ProductsController.cs
@@ -113,12 +113,12 @@ namespace NorthwindCRUD.Controllers
         /// </summary>
         /// <returns>Total count of products as an integer.</returns>
         [HttpGet("GetProductsCount")]
-        public ActionResult<int> GetProductsCount()
+        public ActionResult<CountResultDto> GetProductsCount()
         {
             try
             {
                 var count = productService.GetAllAsQueryable().Count();
-                return Ok(count);
+                return new CountResultDto() { Count = count };
             }
             catch (Exception error)
             {

--- a/NorthwindCRUD/Controllers/ProductsController.cs
+++ b/NorthwindCRUD/Controllers/ProductsController.cs
@@ -57,9 +57,9 @@ namespace NorthwindCRUD.Controllers
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedProducts")]
         public ActionResult<PagedResultDto<ProductDto>> GetAllProducts(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the products. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of products to fetch. If this parameter is not provided, all products are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the products by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+            [FromQuery][Attributes.SwaggerSkipParameter] int? skip,
+            [FromQuery][Attributes.SwaggerTopParameter] int? top,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
         {
             try
             {

--- a/NorthwindCRUD/Controllers/ProductsController.cs
+++ b/NorthwindCRUD/Controllers/ProductsController.cs
@@ -8,6 +8,7 @@ namespace NorthwindCRUD.Controllers
     using NorthwindCRUD.Models.DbModels;
     using NorthwindCRUD.Models.Dtos;
     using NorthwindCRUD.Services;
+    using Swashbuckle.AspNetCore.Annotations;
 
     [ApiController]
     [Route("[controller]")]
@@ -55,15 +56,18 @@ namespace NorthwindCRUD.Controllers
         /// <param name="orderBy">A comma-separated list of fields to order the products by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedProducts")]
-        public ActionResult<PagedResultDto<ProductDto>> GetAllProducts(int? skip, int? top, string? orderBy)
+        public ActionResult<PagedResultDto<ProductDto>> GetAllProducts(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the products. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of products to fetch. If this parameter is not provided, all products are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the products by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
                 // Retrieve all products
-                var products = this.productService.GetAll();
+                var products = this.productService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.GetPagedData<ProductDb, ProductDto>(products, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedDataWithSkip<ProductDb, ProductDto>(products, skip, top, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/RegionsController.cs
+++ b/NorthwindCRUD/Controllers/RegionsController.cs
@@ -7,6 +7,7 @@
     using NorthwindCRUD.Models.Dtos;
     using NorthwindCRUD.Models.InputModels;
     using NorthwindCRUD.Services;
+    using Swashbuckle.AspNetCore.Annotations;
 
     [ApiController]
     [Route("[controller]")]
@@ -50,15 +51,18 @@
         /// <param name="orderBy">A comma-separated list of fields to order the regions by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedRegions")]
-        public ActionResult<PagedResultDto<RegionDto>> GetAllRegions(int? skip, int? top, string? orderBy)
+        public ActionResult<PagedResultDto<RegionDto>> GetAllRegions(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the regions. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of regions to fetch. If this parameter is not provided, all regions are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the regions by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
                 // Retrieve all regions
-                var regions = this.regionService.GetAll();
+                var regions = this.regionService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.GetPagedData<RegionDb, RegionDto>(regions, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedDataWithSkip<RegionDb, RegionDto>(regions, skip, top, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/RegionsController.cs
+++ b/NorthwindCRUD/Controllers/RegionsController.cs
@@ -108,12 +108,12 @@
         /// </summary>
         /// <returns>Total count of regions as an integer.</returns>
         [HttpGet("GetRegionsCount")]
-        public ActionResult<int> GetRegionsCount()
+        public ActionResult<CountResultDto> GetRegionsCount()
         {
             try
             {
                 var count = regionService.GetAllAsQueryable().Count();
-                return Ok(count);
+                return new CountResultDto() { Count = count };
             }
             catch (Exception error)
             {

--- a/NorthwindCRUD/Controllers/RegionsController.cs
+++ b/NorthwindCRUD/Controllers/RegionsController.cs
@@ -62,7 +62,37 @@
                 var regions = this.regionService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.FetchPagedDataWithSkip<RegionDb, RegionDto>(regions, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedData<RegionDb, RegionDto>(regions, skip, top, null, null, orderBy);
+
+                return Ok(pagedResult);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all regions or a page of regions based on the provided parameters.
+        /// </summary>
+        /// <param name="pageIndex">The page index of records to fetch. If this parameter is not provided, fetching starts from the beginning (page 0).</param>
+        /// <param name="size">The maximum number of records to fetch per page. If this parameter is not provided, all records are fetched.</param>
+        /// <param name="orderBy">A comma-separated list of fields to order the records by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
+        /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
+        [HttpGet("GetPagedRegionsWithPage")]
+        public ActionResult<PagedResultDto<RegionDto>> GetPagedRegionsWithPage(
+            [FromQuery][Attributes.SwaggerPageParameter] int? pageIndex,
+            [FromQuery][Attributes.SwaggerSizeParameter] int? size,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
+        {
+            try
+            {
+                // Retrieve regions as Queryable
+                var regions = this.regionService.GetAllAsQueryable();
+
+                // Get paged data
+                var pagedResult = pagingService.FetchPagedData<RegionDb, RegionDto>(regions, null, null, pageIndex, size, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/RegionsController.cs
+++ b/NorthwindCRUD/Controllers/RegionsController.cs
@@ -103,6 +103,25 @@
             }
         }
 
+        /// <summary>
+        /// Retrieves the total number of regions.
+        /// </summary>
+        /// <returns>Total count of regions as an integer.</returns>
+        [HttpGet("GetRegionsCount")]
+        public ActionResult<int> GetRegionsCount()
+        {
+            try
+            {
+                var count = regionService.GetAllAsQueryable().Count();
+                return Ok(count);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
         [HttpGet("{id}")]
         public ActionResult<RegionDto> GetById(int id)
         {

--- a/NorthwindCRUD/Controllers/RegionsController.cs
+++ b/NorthwindCRUD/Controllers/RegionsController.cs
@@ -52,9 +52,9 @@
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedRegions")]
         public ActionResult<PagedResultDto<RegionDto>> GetAllRegions(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the regions. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of regions to fetch. If this parameter is not provided, all regions are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the regions by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+            [FromQuery][Attributes.SwaggerSkipParameter] int? skip,
+            [FromQuery][Attributes.SwaggerTopParameter] int? top,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
         {
             try
             {

--- a/NorthwindCRUD/Controllers/ShippersController.cs
+++ b/NorthwindCRUD/Controllers/ShippersController.cs
@@ -50,8 +50,8 @@
         /// <param name="top">The maximum number of shippers to fetch. If this parameter is not provided, all shippers are fetched.</param>
         /// <param name="orderBy">A comma-separated list of fields to order the shippers by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
-        [HttpGet("GetPagedShippers")]
-        public ActionResult<PagedResultDto<ShipperDto>> GetAllShippers(
+        [HttpGet("GetPagedShippersWithSkip")]
+        public ActionResult<PagedResultDto<ShipperDto>> GetPagedShippersWithSkip(
             [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the shippers. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
             [FromQuery][SwaggerParameter("The maximum number of shippers to fetch. If this parameter is not provided, all shippers are fetched.")] int? top,
             [FromQuery][SwaggerParameter("A comma-separated list of fields to order the shippers by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
@@ -62,7 +62,37 @@
                 var shippers = this.shipperService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.FetchPagedDataWithSkip<ShipperDb, ShipperDto>(shippers, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedData<ShipperDb, ShipperDto>(shippers, skip, top, null, null, orderBy);
+
+                return Ok(pagedResult);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all shippers or a page of shippers based on the provided parameters.
+        /// </summary>
+        /// <param name="pageIndex">The page index of records to fetch. If this parameter is not provided, fetching starts from the beginning (page 0).</param>
+        /// <param name="size">The maximum number of records to fetch per page. If this parameter is not provided, all records are fetched.</param>
+        /// <param name="orderBy">A comma-separated list of fields to order the records by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
+        /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
+        [HttpGet("GetPagedShippersWithPage")]
+        public ActionResult<PagedResultDto<ShipperDto>> GetPagedShippersWithPage(
+            [FromQuery][Attributes.SwaggerPageParameter] int? pageIndex,
+            [FromQuery][Attributes.SwaggerSizeParameter] int? size,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
+        {
+            try
+            {
+                // Retrieve shippers as Queryable
+                var shippers = this.shipperService.GetAllAsQueryable();
+
+                // Get paged data
+                var pagedResult = pagingService.FetchPagedData<RegionDb, RegionDto>(shippers, null, null, pageIndex, size, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/ShippersController.cs
+++ b/NorthwindCRUD/Controllers/ShippersController.cs
@@ -103,6 +103,25 @@
             }
         }
 
+        /// <summary>
+        /// Retrieves the total number of shippers.
+        /// </summary>
+        /// <returns>Total count of shippers as an integer.</returns>
+        [HttpGet("GetShippersCount")]
+        public ActionResult<int> GetShippersCount()
+        {
+            try
+            {
+                var count = shipperService.GetAllAsQueryable().Count();
+                return Ok(count);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
         [HttpGet("{id}")]
         public ActionResult<ShipperDto> GetById(int id)
         {

--- a/NorthwindCRUD/Controllers/ShippersController.cs
+++ b/NorthwindCRUD/Controllers/ShippersController.cs
@@ -52,9 +52,9 @@
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedShippersWithSkip")]
         public ActionResult<PagedResultDto<ShipperDto>> GetPagedShippersWithSkip(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the shippers. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of shippers to fetch. If this parameter is not provided, all shippers are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the shippers by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+            [FromQuery][Attributes.SwaggerSkipParameter] int? skip,
+            [FromQuery][Attributes.SwaggerTopParameter] int? top,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
         {
             try
             {
@@ -92,7 +92,7 @@
                 var shippers = this.shipperService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.FetchPagedData<RegionDb, RegionDto>(shippers, null, null, pageIndex, size, orderBy);
+                var pagedResult = pagingService.FetchPagedData<ShipperDb, ShipperDto>(shippers, null, null, pageIndex, size, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/ShippersController.cs
+++ b/NorthwindCRUD/Controllers/ShippersController.cs
@@ -7,6 +7,7 @@
     using NorthwindCRUD.Models.Dtos;
     using NorthwindCRUD.Models.InputModels;
     using NorthwindCRUD.Services;
+    using Swashbuckle.AspNetCore.Annotations;
 
     [ApiController]
     [Route("[controller]")]
@@ -50,15 +51,18 @@
         /// <param name="orderBy">A comma-separated list of fields to order the shippers by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedShippers")]
-        public ActionResult<PagedResultDto<ShipperDto>> GetAllShippers(int? skip, int? top, string? orderBy)
+        public ActionResult<PagedResultDto<ShipperDto>> GetAllShippers(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the shippers. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of shippers to fetch. If this parameter is not provided, all shippers are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the shippers by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
                 // Retrieve all shippers
-                var shippers = this.shipperService.GetAll();
+                var shippers = this.shipperService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.GetPagedData<ShipperDb, ShipperDto>(shippers, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedDataWithSkip<ShipperDb, ShipperDto>(shippers, skip, top, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/ShippersController.cs
+++ b/NorthwindCRUD/Controllers/ShippersController.cs
@@ -108,12 +108,12 @@
         /// </summary>
         /// <returns>Total count of shippers as an integer.</returns>
         [HttpGet("GetShippersCount")]
-        public ActionResult<int> GetShippersCount()
+        public ActionResult<CountResultDto> GetShippersCount()
         {
             try
             {
                 var count = shipperService.GetAllAsQueryable().Count();
-                return Ok(count);
+                return new CountResultDto() { Count = count };
             }
             catch (Exception error)
             {

--- a/NorthwindCRUD/Controllers/SuppliersController.cs
+++ b/NorthwindCRUD/Controllers/SuppliersController.cs
@@ -7,6 +7,7 @@
     using NorthwindCRUD.Models.Dtos;
     using NorthwindCRUD.Models.InputModels;
     using NorthwindCRUD.Services;
+    using Swashbuckle.AspNetCore.Annotations;
 
     [ApiController]
     [Route("[controller]")]
@@ -50,15 +51,18 @@
         /// <param name="orderBy">A comma-separated list of fields to order the suppliers by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedSuppliers")]
-        public ActionResult<PagedResultDto<SupplierDto>> GetAllSuppliers(int? skip, int? top, string? orderBy)
+        public ActionResult<PagedResultDto<SupplierDto>> GetAllSuppliers(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the suppliers. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of suppliers to fetch. If this parameter is not provided, all suppliers are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the suppliers by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
                 // Retrieve all suppliers
-                var suppliers = this.supplierService.GetAll();
+                var suppliers = this.supplierService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.GetPagedData<SupplierDb, SupplierDto>(suppliers, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedDataWithSkip<SupplierDb, SupplierDto>(suppliers, skip, top, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/SuppliersController.cs
+++ b/NorthwindCRUD/Controllers/SuppliersController.cs
@@ -62,7 +62,37 @@
                 var suppliers = this.supplierService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.FetchPagedDataWithSkip<SupplierDb, SupplierDto>(suppliers, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedData<SupplierDb, SupplierDto>(suppliers, skip, top, null, null, orderBy);
+
+                return Ok(pagedResult);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all suppliers or a page of suppliers based on the provided parameters.
+        /// </summary>
+        /// <param name="pageIndex">The page index of records to fetch. If this parameter is not provided, fetching starts from the beginning (page 0).</param>
+        /// <param name="size">The maximum number of records to fetch per page. If this parameter is not provided, all records are fetched.</param>
+        /// <param name="orderBy">A comma-separated list of fields to order the records by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
+        /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
+        [HttpGet("GetPagedSuppliersWithPage")]
+        public ActionResult<PagedResultDto<SupplierDto>> GetPagedSuppliersWithPage(
+            [FromQuery][Attributes.SwaggerPageParameter] int? pageIndex,
+            [FromQuery][Attributes.SwaggerSizeParameter] int? size,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
+        {
+            try
+            {
+                // Retrieve suppliers as Queryable
+                var suppliers = this.supplierService.GetAllAsQueryable();
+
+                // Get paged data
+                var pagedResult = pagingService.FetchPagedData<SupplierDb, SupplierDto>(suppliers, null, null, pageIndex, size, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/SuppliersController.cs
+++ b/NorthwindCRUD/Controllers/SuppliersController.cs
@@ -103,6 +103,25 @@
             }
         }
 
+        /// <summary>
+        /// Retrieves the total number of suppliers.
+        /// </summary>
+        /// <returns>Total count of suppliers as an integer.</returns>
+        [HttpGet("GetSuppliersCount")]
+        public ActionResult<int> GetSuppliersCount()
+        {
+            try
+            {
+                var count = supplierService.GetAllAsQueryable().Count();
+                return Ok(count);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
         [HttpGet("{id}")]
         public ActionResult<SupplierDto> GetById(int id)
         {

--- a/NorthwindCRUD/Controllers/SuppliersController.cs
+++ b/NorthwindCRUD/Controllers/SuppliersController.cs
@@ -52,9 +52,9 @@
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedSuppliers")]
         public ActionResult<PagedResultDto<SupplierDto>> GetAllSuppliers(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the suppliers. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of suppliers to fetch. If this parameter is not provided, all suppliers are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the suppliers by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+            [FromQuery][Attributes.SwaggerSkipParameter] int? skip,
+            [FromQuery][Attributes.SwaggerTopParameter] int? top,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
         {
             try
             {

--- a/NorthwindCRUD/Controllers/SuppliersController.cs
+++ b/NorthwindCRUD/Controllers/SuppliersController.cs
@@ -108,12 +108,12 @@
         /// </summary>
         /// <returns>Total count of suppliers as an integer.</returns>
         [HttpGet("GetSuppliersCount")]
-        public ActionResult<int> GetSuppliersCount()
+        public ActionResult<CountResultDto> GetSuppliersCount()
         {
             try
             {
                 var count = supplierService.GetAllAsQueryable().Count();
-                return Ok(count);
+                return new CountResultDto() { Count = count };
             }
             catch (Exception error)
             {

--- a/NorthwindCRUD/Controllers/TerritoriesController.cs
+++ b/NorthwindCRUD/Controllers/TerritoriesController.cs
@@ -105,6 +105,25 @@
             }
         }
 
+        /// <summary>
+        /// Retrieves the total number of territories.
+        /// </summary>
+        /// <returns>Total count of territories as an integer.</returns>
+        [HttpGet("GetTerritoriesCount")]
+        public ActionResult<int> GetTerritoriesCount()
+        {
+            try
+            {
+                var count = territoryService.GetAllAsQueryable().Count();
+                return Ok(count);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
         [HttpGet("{id}")]
         public ActionResult<TerritoryDto> GetById(string id)
         {

--- a/NorthwindCRUD/Controllers/TerritoriesController.cs
+++ b/NorthwindCRUD/Controllers/TerritoriesController.cs
@@ -110,12 +110,12 @@
         /// </summary>
         /// <returns>Total count of territories as an integer.</returns>
         [HttpGet("GetTerritoriesCount")]
-        public ActionResult<int> GetTerritoriesCount()
+        public ActionResult<CountResultDto> GetTerritoriesCount()
         {
             try
             {
                 var count = territoryService.GetAllAsQueryable().Count();
-                return Ok(count);
+                return new CountResultDto() { Count = count };
             }
             catch (Exception error)
             {

--- a/NorthwindCRUD/Controllers/TerritoriesController.cs
+++ b/NorthwindCRUD/Controllers/TerritoriesController.cs
@@ -54,9 +54,9 @@
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedTerritories")]
         public ActionResult<PagedResultDto<TerritoryDto>> GetAllTerritories(
-            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the territories. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
-            [FromQuery][SwaggerParameter("The maximum number of territories to fetch. If this parameter is not provided, all territories are fetched.")] int? top,
-            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the territories by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
+            [FromQuery][Attributes.SwaggerSkipParameter] int? skip,
+            [FromQuery][Attributes.SwaggerTopParameter] int? top,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
         {
             try
             {

--- a/NorthwindCRUD/Controllers/TerritoriesController.cs
+++ b/NorthwindCRUD/Controllers/TerritoriesController.cs
@@ -7,6 +7,7 @@
     using NorthwindCRUD.Models.Dtos;
     using NorthwindCRUD.Models.InputModels;
     using NorthwindCRUD.Services;
+    using Swashbuckle.AspNetCore.Annotations;
 
     [ApiController]
     [Route("[controller]")]
@@ -52,15 +53,18 @@
         /// <param name="orderBy">A comma-separated list of fields to order the territories by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
         /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
         [HttpGet("GetPagedTerritories")]
-        public ActionResult<PagedResultDto<TerritoryDto>> GetAllTerritories(int? skip, int? top, string? orderBy)
+        public ActionResult<PagedResultDto<TerritoryDto>> GetAllTerritories(
+            [FromQuery][SwaggerParameter("The number of records to skip before starting to fetch the territories. If this parameter is not provided, fetching starts from the beginning.")] int? skip,
+            [FromQuery][SwaggerParameter("The maximum number of territories to fetch. If this parameter is not provided, all territories are fetched.")] int? top,
+            [FromQuery][SwaggerParameter("A comma-separated list of fields to order the territories by, along with the sort direction (e.g., 'field1 asc, field2 desc').")] string? orderBy)
         {
             try
             {
                 // Retrieve all territories
-                var territories = this.territoryService.GetAll();
+                var territories = this.territoryService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.GetPagedData<TerritoryDb, TerritoryDto>(territories, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedDataWithSkip<TerritoryDb, TerritoryDto>(territories, skip, top, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Controllers/TerritoriesController.cs
+++ b/NorthwindCRUD/Controllers/TerritoriesController.cs
@@ -64,7 +64,37 @@
                 var territories = this.territoryService.GetAllAsQueryable();
 
                 // Get paged data
-                var pagedResult = pagingService.FetchPagedDataWithSkip<TerritoryDb, TerritoryDto>(territories, skip, top, orderBy);
+                var pagedResult = pagingService.FetchPagedData<TerritoryDb, TerritoryDto>(territories, skip, top, null, null, orderBy);
+
+                return Ok(pagedResult);
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error.Message);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// Fetches all territories or a page of territories based on the provided parameters.
+        /// </summary>
+        /// <param name="pageIndex">The page index of records to fetch. If this parameter is not provided, fetching starts from the beginning (page 0).</param>
+        /// <param name="size">The maximum number of records to fetch per page. If this parameter is not provided, all territories are fetched.</param>
+        /// <param name="orderBy">A comma-separated list of fields to order the territories by, along with the sort direction (e.g., "field1 asc, field2 desc").</param>
+        /// <returns>A PagedResultDto object containing the fetched T and the total record count.</returns>
+        [HttpGet("GetPagedTerritoriesWithPage")]
+        public ActionResult<PagedResultDto<TerritoryDto>> GetPagedTerritoriesWithPage(
+            [FromQuery][Attributes.SwaggerPageParameter] int? pageIndex,
+            [FromQuery][Attributes.SwaggerSizeParameter] int? size,
+            [FromQuery][Attributes.SwaggerOrderByParameter] string? orderBy)
+        {
+            try
+            {
+                // Retrieve territories as Queryable
+                var territories = this.territoryService.GetAllAsQueryable();
+
+                // Get paged data
+                var pagedResult = pagingService.FetchPagedData<TerritoryDb, TerritoryDto>(territories, null, null, pageIndex, size, orderBy);
 
                 return Ok(pagedResult);
             }

--- a/NorthwindCRUD/Models/Dtos/CountResultDto.cs
+++ b/NorthwindCRUD/Models/Dtos/CountResultDto.cs
@@ -1,0 +1,7 @@
+﻿namespace NorthwindCRUD.Models.Dtos
+{
+    public class CountResultDto
+    {
+        public int Count { get; set; }
+    }
+}

--- a/NorthwindCRUD/Services/CategoryService.cs
+++ b/NorthwindCRUD/Services/CategoryService.cs
@@ -1,5 +1,6 @@
 ﻿namespace NorthwindCRUD.Services
 {
+    using Microsoft.EntityFrameworkCore;
     using NorthwindCRUD.Helpers;
     using NorthwindCRUD.Models.DbModels;
 
@@ -15,6 +16,11 @@
         public CategoryDb[] GetAll()
         {
             return this.dataContext.Categories.ToArray();
+        }
+
+        public IQueryable<CategoryDb> GetAllAsQueryable()
+        {
+            return this.dataContext.Categories.AsQueryable();
         }
 
         public CategoryDb? GetById(int id)

--- a/NorthwindCRUD/Services/CategoryService.cs
+++ b/NorthwindCRUD/Services/CategoryService.cs
@@ -20,7 +20,7 @@
 
         public IQueryable<CategoryDb> GetAllAsQueryable()
         {
-            return this.dataContext.Categories.AsQueryable();
+            return this.dataContext.Categories;
         }
 
         public CategoryDb? GetById(int id)

--- a/NorthwindCRUD/Services/CustomerService.cs
+++ b/NorthwindCRUD/Services/CustomerService.cs
@@ -20,6 +20,11 @@ namespace NorthwindCRUD.Services
                 .ToArray();
         }
 
+        public IQueryable<CustomerDb> GetAllAsQueryable()
+        {
+            return this.dataContext.Customers.AsQueryable();
+        }
+
         public CustomerDb? GetById(string id)
         {
             return this.dataContext.Customers

--- a/NorthwindCRUD/Services/CustomerService.cs
+++ b/NorthwindCRUD/Services/CustomerService.cs
@@ -22,7 +22,7 @@ namespace NorthwindCRUD.Services
 
         public IQueryable<CustomerDb> GetAllAsQueryable()
         {
-            return this.dataContext.Customers.AsQueryable();
+            return this.dataContext.Customers;
         }
 
         public CustomerDb? GetById(string id)

--- a/NorthwindCRUD/Services/EmployeeService.cs
+++ b/NorthwindCRUD/Services/EmployeeService.cs
@@ -22,7 +22,7 @@
 
         public IQueryable<EmployeeDb> GetAllAsQueryable()
         {
-            return this.dataContext.Employees.AsQueryable();
+            return this.dataContext.Employees;
         }
 
         public EmployeeDb? GetById(int id)

--- a/NorthwindCRUD/Services/EmployeeService.cs
+++ b/NorthwindCRUD/Services/EmployeeService.cs
@@ -20,6 +20,11 @@
                 .ToArray();
         }
 
+        public IQueryable<EmployeeDb> GetAllAsQueryable()
+        {
+            return this.dataContext.Employees.AsQueryable();
+        }
+
         public EmployeeDb? GetById(int id)
         {
             return this.dataContext.Employees.FirstOrDefault(c => c.EmployeeId == id);

--- a/NorthwindCRUD/Services/OrderService.cs
+++ b/NorthwindCRUD/Services/OrderService.cs
@@ -23,6 +23,11 @@ namespace NorthwindCRUD.Services
                 .ToArray();
         }
 
+        public IQueryable<OrderDb> GetAllAsQueryable()
+        {
+            return this.dataContext.Orders.AsQueryable();
+        }
+
         public OrderDb[] GetNOrders(int numberOfOrdersToRetrieve)
         {
             return this.dataContext.Orders

--- a/NorthwindCRUD/Services/OrderService.cs
+++ b/NorthwindCRUD/Services/OrderService.cs
@@ -25,7 +25,7 @@ namespace NorthwindCRUD.Services
 
         public IQueryable<OrderDb> GetAllAsQueryable()
         {
-            return this.dataContext.Orders.AsQueryable();
+            return this.dataContext.Orders;
         }
 
         public OrderDb[] GetNOrders(int numberOfOrdersToRetrieve)

--- a/NorthwindCRUD/Services/PagingService.cs
+++ b/NorthwindCRUD/Services/PagingService.cs
@@ -74,7 +74,7 @@ namespace NorthwindCRUD.Services
                 Items = pagedDataDtos,
                 TotalRecordsCount = totalRecords,
                 PageSize = currentSize,
-                PageNumber = isPageSize ? ((skipRecordsAmount / currentSize) + 1) : ((skipRecordsAmount / currentSize) + 1),
+                PageNumber = currentSize != 0 ? (isPageIndexAndSize ? (skipRecordsAmount / currentSize) : (skipRecordsAmount / currentSize) + 1) : default,
                 TotalPages = totalPages,
             };
         }

--- a/NorthwindCRUD/Services/PagingService.cs
+++ b/NorthwindCRUD/Services/PagingService.cs
@@ -14,7 +14,7 @@ namespace NorthwindCRUD.Services
             IQueryable<TEntity> query,
             int? skip = null,
             int? top = null,
-            int? page = null,
+            int? pageIndex = null,
             int? size = null,
             string? orderBy = null);
     }

--- a/NorthwindCRUD/Services/PagingService.cs
+++ b/NorthwindCRUD/Services/PagingService.cs
@@ -34,8 +34,8 @@ namespace NorthwindCRUD.Services
             int? size = null,
             string? orderBy = null)
         {
-            // Determine if we're using skip/top or page/size
-            bool isPageSize = pageIndex.HasValue || size.HasValue;
+            // Determine if we're using skip/top or pageIndex/size
+            bool isPageIndexAndSize = pageIndex.HasValue || size.HasValue;
 
             int totalRecords = query.Count();
 
@@ -43,7 +43,7 @@ namespace NorthwindCRUD.Services
             int skipRecordsAmount = skip ?? 0;
             int currentSize = top ?? totalRecords;
 
-            if (isPageSize)
+            if (isPageIndexAndSize)
             {
                 int pageNumber = pageIndex ?? 0;
                 int pageSize = size ?? totalRecords;

--- a/NorthwindCRUD/Services/ProductService.cs
+++ b/NorthwindCRUD/Services/ProductService.cs
@@ -21,7 +21,7 @@ namespace NorthwindCRUD.Services
 
         public IQueryable<ProductDb> GetAllAsQueryable()
         {
-            return this.dataContext.Products.AsQueryable();
+            return this.dataContext.Products;
         }
 
         public ProductDb? GetById(int id)

--- a/NorthwindCRUD/Services/ProductService.cs
+++ b/NorthwindCRUD/Services/ProductService.cs
@@ -19,6 +19,11 @@ namespace NorthwindCRUD.Services
             return this.dataContext.Products.ToArray();
         }
 
+        public IQueryable<ProductDb> GetAllAsQueryable()
+        {
+            return this.dataContext.Products.AsQueryable();
+        }
+
         public ProductDb? GetById(int id)
         {
             return this.dataContext.Products.FirstOrDefault(p => p.ProductId == id);

--- a/NorthwindCRUD/Services/RegionService.cs
+++ b/NorthwindCRUD/Services/RegionService.cs
@@ -17,6 +17,11 @@ namespace NorthwindCRUD.Services
             return this.dataContext.Regions.ToArray();
         }
 
+        public IQueryable<RegionDb> GetAllAsQueryable()
+        {
+            return this.dataContext.Regions.AsQueryable();
+        }
+
         public RegionDb? GetById(int id)
         {
             return this.dataContext.Regions.FirstOrDefault(p => p.RegionId == id);

--- a/NorthwindCRUD/Services/RegionService.cs
+++ b/NorthwindCRUD/Services/RegionService.cs
@@ -19,7 +19,7 @@ namespace NorthwindCRUD.Services
 
         public IQueryable<RegionDb> GetAllAsQueryable()
         {
-            return this.dataContext.Regions.AsQueryable();
+            return this.dataContext.Regions;
         }
 
         public RegionDb? GetById(int id)

--- a/NorthwindCRUD/Services/ShipperService.cs
+++ b/NorthwindCRUD/Services/ShipperService.cs
@@ -17,6 +17,11 @@ namespace NorthwindCRUD.Services
             return this.dataContext.Shippers.ToArray();
         }
 
+        public IQueryable<ShipperDb> GetAllAsQueryable()
+        {
+            return this.dataContext.Shippers.AsQueryable();
+        }
+
         public ShipperDb? GetById(int id)
         {
             return this.dataContext.Shippers.FirstOrDefault(p => p.ShipperId == id);

--- a/NorthwindCRUD/Services/ShipperService.cs
+++ b/NorthwindCRUD/Services/ShipperService.cs
@@ -19,7 +19,7 @@ namespace NorthwindCRUD.Services
 
         public IQueryable<ShipperDb> GetAllAsQueryable()
         {
-            return this.dataContext.Shippers.AsQueryable();
+            return this.dataContext.Shippers;
         }
 
         public ShipperDb? GetById(int id)

--- a/NorthwindCRUD/Services/SupplierService.cs
+++ b/NorthwindCRUD/Services/SupplierService.cs
@@ -19,7 +19,7 @@ namespace NorthwindCRUD.Services
 
         public IQueryable<SupplierDb> GetAllAsQueryable()
         {
-            return this.dataContext.Suppliers.AsQueryable();
+            return this.dataContext.Suppliers;
         }
 
         public SupplierDb? GetById(int id)

--- a/NorthwindCRUD/Services/SupplierService.cs
+++ b/NorthwindCRUD/Services/SupplierService.cs
@@ -17,6 +17,11 @@ namespace NorthwindCRUD.Services
             return this.dataContext.Suppliers.ToArray();
         }
 
+        public IQueryable<SupplierDb> GetAllAsQueryable()
+        {
+            return this.dataContext.Suppliers.AsQueryable();
+        }
+
         public SupplierDb? GetById(int id)
         {
             return this.dataContext.Suppliers.FirstOrDefault(p => p.SupplierId == id);

--- a/NorthwindCRUD/Services/TerritoryService.cs
+++ b/NorthwindCRUD/Services/TerritoryService.cs
@@ -19,6 +19,11 @@ namespace NorthwindCRUD.Services
             return this.dataContext.Territories.ToArray();
         }
 
+        public IQueryable<TerritoryDb> GetAllAsQueryable()
+        {
+            return this.dataContext.Territories.AsQueryable();
+        }
+
         public TerritoryDb? GetById(string id)
         {
             return this.dataContext.Territories.FirstOrDefault(t => t.TerritoryId == id);

--- a/NorthwindCRUD/Services/TerritoryService.cs
+++ b/NorthwindCRUD/Services/TerritoryService.cs
@@ -21,7 +21,7 @@ namespace NorthwindCRUD.Services
 
         public IQueryable<TerritoryDb> GetAllAsQueryable()
         {
-            return this.dataContext.Territories.AsQueryable();
+            return this.dataContext.Territories;
         }
 
         public TerritoryDb? GetById(string id)


### PR DESCRIPTION
The PR is:
- Adding a new endpoint for pageIndex and size - `GetCategoriesWithPage` and so on
- Updating the existing method for skip and top - `GetCategoriesWithSkip` 
- Adding performance improvement when fetching the entities
- Adding new custom swagger attributes for pageIndex, size, skip, top and group by

In essence, now we support two configurations:
- the user can send skip and top parameters, **in which case the top will be pre-calculated**.
- the user can send pageIndex and size parameters, **and the service will calculate the chunk of data that should be fetched**