### PR TITLE
Fix multiple concurrent connections issue

### DIFF
--- a/NorthwindCRUD/Providers/DbContextConfigurationProvider.cs
+++ b/NorthwindCRUD/Providers/DbContextConfigurationProvider.cs
@@ -6,7 +6,7 @@ using NorthwindCRUD.Helpers;
 
 namespace NorthwindCRUD.Providers
 {
-    public class DbContextConfigurationProvider
+    public class DbContextConfigurationProvider : IDisposable
     {
         private const string DefaultTenantId = "default-tenant";
         private const string TenantHeaderKey = "X-Tenant-ID";
@@ -15,6 +15,8 @@ namespace NorthwindCRUD.Providers
         private readonly IHttpContextAccessor context;
         private readonly IMemoryCache memoryCache;
         private readonly IConfiguration configuration;
+
+        private SqliteConnection? currentRequestConnection;
 
         public DbContextConfigurationProvider(IHttpContextAccessor context, IMemoryCache memoryCache, IConfiguration configuration)
         {
@@ -34,27 +36,39 @@ namespace NorthwindCRUD.Providers
             else if (dbProvider == "SQLite")
             {
                 var tenantId = GetTenantId();
+                var connectionString = this.GetSqlLiteConnectionString(tenantId);
 
                 var cacheKey = string.Format(CultureInfo.InvariantCulture, DatabaseConnectionCacheKey, tenantId);
 
                 if (!memoryCache.TryGetValue(cacheKey, out SqliteConnection connection))
                 {
-                    var connectionString = this.GetSqlLiteConnectionString(tenantId);
+                    // Create a cached connection to seed the database and keep the data alive
                     connection = new SqliteConnection(connectionString);
                     memoryCache.Set(cacheKey, connection, GetCacheConnectionEntryOptions());
-
-                    // For SQLite in memory to be shared across multiple EF calls, we need to maintain a separate open connection.
-                    // see post https://stackoverflow.com/questions/56319638/entityframeworkcore-sqlite-in-memory-db-tables-are-not-created
                     connection.Open();
 
                     options.UseSqlite(connection).EnableSensitiveDataLogging();
-
                     SeedDb(options);
                 }
-                else
-                {
-                    options.UseSqlite(connection).EnableSensitiveDataLogging();
-                }
+
+                // Create a new connection per request to avoid threading issues
+                currentRequestConnection = new SqliteConnection(connectionString);
+                currentRequestConnection.Open();
+                options.UseSqlite(currentRequestConnection).EnableSensitiveDataLogging();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                currentRequestConnection?.Close();
             }
         }
 


### PR DESCRIPTION
Fix multiple concurrent connections issue

This is easy to reproduce in the following case:
 - Use Firefox
 - In App Builder create a Tree
 - Make the first level repeat on Northwind Swagger / Customers
 - Make the second level repeat on Northwind Swagger / Customers/{id}/Orders
   (correctly link the customer id parameter)
 - Go to preview
 - Open the devtools
 - Refresh

You can see some response errors:
![image](https://github.com/user-attachments/assets/ce7a2fc8-a5cb-4890-8119-ecf6113f5947)

With this fix there are no longer any errors.
And requests in this scenario seem to be a lot faster.