### PR TITLE
Make address fields nullable, improve phone regex to support dashes

### DIFF
--- a/NorthwindCRUD/Models/Contracts/IAddress.cs
+++ b/NorthwindCRUD/Models/Contracts/IAddress.cs
@@ -4,15 +4,15 @@ namespace NorthwindCRUD.Models.Contracts
 {
     public interface IAddress
     {
-        string Street { get; set; }
+        string? Street { get; set; }
 
-        string City { get; set; }
+        string? City { get; set; }
 
-        string Region { get; set; }
+        string? Region { get; set; }
 
-        string PostalCode { get; set; }
+        string? PostalCode { get; set; }
 
-        string Country { get; set; }
+        string? Country { get; set; }
 
         string? Phone { get; set; }
     }

--- a/NorthwindCRUD/Models/DbModels/AddressDb.cs
+++ b/NorthwindCRUD/Models/DbModels/AddressDb.cs
@@ -10,15 +10,15 @@ namespace NorthwindCRUD.Models.DbModels
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public string AddressId { get; set; }
 
-        public string Street { get; set; }
+        public string? Street { get; set; }
 
-        public string City { get; set; }
+        public string? City { get; set; }
 
-        public string Region { get; set; }
+        public string? Region { get; set; }
 
-        public string PostalCode { get; set; }
+        public string? PostalCode { get; set; }
 
-        public string Country { get; set; }
+        public string? Country { get; set; }
 
         public string? Phone { get; set; }
 

--- a/NorthwindCRUD/Models/Dtos/AddressDto.cs
+++ b/NorthwindCRUD/Models/Dtos/AddressDto.cs
@@ -5,25 +5,20 @@ namespace NorthwindCRUD.Models.Dtos
 {
     public class AddressDto : IAddress
     {
-        [Required(ErrorMessage = "Street is required.")]
         [StringLength(100, ErrorMessage = "Street cannot exceed 100 characters.")]
-        public string Street { get; set; }
+        public string? Street { get; set; }
 
-        [Required(ErrorMessage = "City is required.")]
         [StringLength(50, ErrorMessage = "City cannot exceed 50 characters.")]
-        public string City { get; set; }
+        public string? City { get; set; }
 
-        [Required(ErrorMessage = "Region is required.")]
         [StringLength(50, ErrorMessage = "Region cannot exceed 50 characters.")]
-        public string Region { get; set; }
+        public string? Region { get; set; }
 
-        [Required(ErrorMessage = "PostalCode is required.")]
         [StringLength(20, ErrorMessage = "Postal code cannot exceed 20 characters.")]
-        public string PostalCode { get; set; }
+        public string? PostalCode { get; set; }
 
-        [Required(ErrorMessage = "Country is required.")]
         [StringLength(50, ErrorMessage = "Country cannot exceed 50 characters.")]
-        public string Country { get; set; }
+        public string? Country { get; set; }
 
         [RegularExpression(@"^\+?[1-9]\d{1,14}$", ErrorMessage = "Phone number is not valid.")]
         public string? Phone { get; set; }

--- a/NorthwindCRUD/Models/Dtos/AddressDto.cs
+++ b/NorthwindCRUD/Models/Dtos/AddressDto.cs
@@ -20,7 +20,7 @@ namespace NorthwindCRUD.Models.Dtos
         [StringLength(50, ErrorMessage = "Country cannot exceed 50 characters.")]
         public string? Country { get; set; }
 
-        [RegularExpression(@"^\+?[1-9]\d{1,14}$", ErrorMessage = "Phone number is not valid.")]
+        [RegularExpression(@"^\+?[0-9][0-9\-]{1,14}$", ErrorMessage = "Phone number is not valid.")]
         public string? Phone { get; set; }
     }
 }

--- a/NorthwindCRUD/Services/SalesService.cs
+++ b/NorthwindCRUD/Services/SalesService.cs
@@ -71,7 +71,7 @@ namespace NorthwindCRUD.Services
             .ToList();
 
             var filteredData = salesData
-            .Where(od => od.Order.ShipAddress?.Country.ToLower(CultureInfo.InvariantCulture) == normalizedCountry && DateTime.Parse(od.Order.OrderDate, CultureInfo.InvariantCulture) >= parsedStartDate && DateTime.Parse(od.Order.RequiredDate, CultureInfo.InvariantCulture) <= parsedEndDate)
+            .Where(od => od.Order.ShipAddress?.Country?.ToLower(CultureInfo.InvariantCulture) == normalizedCountry && DateTime.Parse(od.Order.OrderDate, CultureInfo.InvariantCulture) >= parsedStartDate && DateTime.Parse(od.Order.RequiredDate, CultureInfo.InvariantCulture) <= parsedEndDate)
             .ToList();
 
             var sales = filteredData.Select(od => new SalesDto


### PR DESCRIPTION
Made all address fields nullable in the Dto object.
Also all field are made nullable in the Db object, as EF is throwing an exception if we try to save null in the DB.
Phone number regex to support dashes and phones starting with 0