### PR TITLE
increase jwt key size

### DIFF
--- a/NorthwindCRUD/appsettings.json
+++ b/NorthwindCRUD/appsettings.json
@@ -16,6 +16,6 @@
   "Jwt": {
     "Issuer": "https://localhost:7244/",
     "Audience": "https://localhost:7244/",
-    "Key": "S1u*p7e_r+S2e/c4r6e7t*0K/e7y"
+    "Key": "HxFL4p5Lac7IeTxLTT+f60GpxL/5trJYS08cIEvpHi2/-oqeZ4Boa7E*u_mcyu2+"
   }
 }


### PR DESCRIPTION
Updated to the latest JwtSecurityTokenHandler, which now requires a stronger signing key - 512bits.

Old key: 224-bit (28 chars)

New key: 512-bit (64 chars)

Ensures compatibility and improved security with the new handler.